### PR TITLE
'Hide' the underscores that stretch the User Profile.

### DIFF
--- a/src/app/ui/user-settings.tsx
+++ b/src/app/ui/user-settings.tsx
@@ -20,7 +20,7 @@ const UserSettingActive = ({ user }) => {
         <PopoverContent>
           <div className="px-1 py-2">
             <p>User Profile</p>
-            <div>____________________________________</div>
+            <div style={{ color: '#FFFFFF' }}>____________________________________</div>
             <Select
               label="Education relation"
               placeholder={EducationRelation}


### PR DESCRIPTION
Currently there is a row of underscores used in the User profile. These are used because the popover doesn't recognize the size of the dropdown, and as such would normally not scale correctly. The underscores are jarring to look at so I put in a quick hack to hide them for now. In the future I want to remove the underscores entirely, but this hack will let us look more professional for the expo.